### PR TITLE
Fix proposal for thread destruction.

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -228,7 +228,7 @@ namespace velodyne
                     #if defined( HAVE_BOOST ) && defined( HAVE_PCAP )
                     ||
                     #endif
-                    #ifdef HAVE_PCAP 
+                    #ifdef HAVE_PCAP
                     pcap != nullptr
                     #endif
                     #else
@@ -249,10 +249,10 @@ namespace velodyne
             void close()
             {
                 std::lock_guard<std::mutex> lock( mutex );
-
+                run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
-                    thread->detach();
+                    thread->join();
                     thread->~thread();
                     delete thread;
                     thread = nullptr;
@@ -321,7 +321,7 @@ namespace velodyne
                 unsigned char data[1500];
                 boost::asio::ip::udp::endpoint sender;
 
-                while( socket->is_open() && ioservice.stopped() ){
+                while( socket->is_open() && ioservice.stopped() && run ){
                     // Receive Packet
                     boost::system::error_code error;
                     const size_t length = socket->receive_from( boost::asio::buffer( data, sizeof( data ) ), sender, 0, error );
@@ -417,7 +417,7 @@ namespace velodyne
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;
 
-                while( true ){
+                while( run ){
                     // Retrieve Header and Data from PCAP
                     struct pcap_pkthdr* header;
                     const unsigned char* data;

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -228,7 +228,7 @@ namespace velodyne
                     #if defined( HAVE_BOOST ) && defined( HAVE_PCAP )
                     ||
                     #endif
-                    #ifdef HAVE_PCAP 
+                    #ifdef HAVE_PCAP
                     pcap != nullptr
                     #endif
                     #else
@@ -249,10 +249,10 @@ namespace velodyne
             void close()
             {
                 std::lock_guard<std::mutex> lock( mutex );
-
+                run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
-                    thread->detach();
+                    thread->join();
                     thread->~thread();
                     delete thread;
                     thread = nullptr;
@@ -321,7 +321,7 @@ namespace velodyne
                 unsigned char data[1500];
                 boost::asio::ip::udp::endpoint sender;
 
-                while( socket->is_open() && ioservice.stopped() ){
+                while( socket->is_open() && ioservice.stopped() && run ){
                     // Receive Packet
                     boost::system::error_code error;
                     const size_t length = socket->receive_from( boost::asio::buffer( data, sizeof( data ) ), sender, 0, error );
@@ -417,7 +417,7 @@ namespace velodyne
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;
 
-                while( true ){
+                while( run ){
                     // Retrieve Header and Data from PCAP
                     struct pcap_pkthdr* header;
                     const unsigned char* data;

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -228,7 +228,7 @@ namespace velodyne
                     #if defined( HAVE_BOOST ) && defined( HAVE_PCAP )
                     ||
                     #endif
-                    #ifdef HAVE_PCAP 
+                    #ifdef HAVE_PCAP
                     pcap != nullptr
                     #endif
                     #else
@@ -249,10 +249,10 @@ namespace velodyne
             void close()
             {
                 std::lock_guard<std::mutex> lock( mutex );
-
+                run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
-                    thread->detach();
+                    thread->join();
                     thread->~thread();
                     delete thread;
                     thread = nullptr;
@@ -321,7 +321,7 @@ namespace velodyne
                 unsigned char data[1500];
                 boost::asio::ip::udp::endpoint sender;
 
-                while( socket->is_open() && ioservice.stopped() ){
+                while( socket->is_open() && ioservice.stopped() && run ){
                     // Receive Packet
                     boost::system::error_code error;
                     const size_t length = socket->receive_from( boost::asio::buffer( data, sizeof( data ) ), sender, 0, error );
@@ -417,7 +417,7 @@ namespace velodyne
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;
 
-                while( true ){
+                while( run ){
                     // Retrieve Header and Data from PCAP
                     struct pcap_pkthdr* header;
                     const unsigned char* data;


### PR DESCRIPTION


For some reason the Issue button is "grayed out" so I can't submit an issue. Anyway this was the issue

I am getting a segfault when calling the destructor on gcc whenever I am using the simple/main.cpp with a pcap. Calling the destructor on the thread seems to be the cause of it. 

### Backtrace 
```
#0  0x00007ffff6e7b637 in pcap_next_ex () from /usr/lib/x86_64-linux-gnu/libpcap.so.0.8
#1  0x0000555555560dd3 in velodyne::VelodyneCapture::capturePCAP (this=0x7fffffffde60)
    at /home/e/pro/alcor2-dev/dev/py-grabber/../VelodyneCapture/VelodyneCapture.h:423
#2  0x000055555556c304 in std::__invoke_impl<void, void (velodyne::VelodyneCapture::*&)(), velodyne::VelodyneCapture*&> (
    __f=@0x5555557ad0e8: (void (velodyne::VelodyneCapture::*)(velodyne::VelodyneCapture * const)) 0x555555560d5c <velodyne::VelodyneCapture::capturePCAP()>, __t=@0x5555557ad0f8: 0x7fffffffde60)
    at /usr/include/c++/7/bits/invoke.h:73
#3  0x000055555556ad9d in std::__invoke<void (velodyne::VelodyneCapture::*&)(), velodyne::VelodyneCapture*&> (
    __fn=@0x5555557ad0e8: (void (velodyne::VelodyneCapture::*)(velodyne::VelodyneCapture * const)) 0x555555560d5c <velodyne::VelodyneCapture::capturePCAP()>, __args#0=@0x5555557ad0f8: 0x7fffffffde60)
    at /usr/include/c++/7/bits/invoke.h:95
#4  0x00005555555697e1 in std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0x5555557ad0e8, __args=...)
    at /usr/include/c++/7/functional:467
#5  0x0000555555567893 in std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>::operator()<, void>() (this=0x5555557ad0e8) at /usr/include/c++/7/functional:551
#6  0x000055555556526f in std::__invoke_impl<void, std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>>(std::__invoke_other, std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>&&) (__f=...) at /usr/include/c++/7/bits/invoke.h:60
#7  0x0000555555562d35 in std::__invoke<std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>>(std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()>&&) (
    __fn=...) at /usr/include/c++/7/bits/invoke.h:95
#8  0x0000555555572886 in std::thread::_Invoker<std::tuple<std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x5555557ad0e8)
    at /usr/include/c++/7/thread:234
#9  0x0000555555571f41 in std::thread::_Invoker<std::tuple<std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()> > >::operator()() (this=0x5555557ad0e8)
    at /usr/include/c++/7/thread:243
#10 0x0000555555571568 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind<void (velodyne::VelodyneCapture::*(velodyne::VelodyneCapture*))()> > > >::_M_run() (this=0x5555557ad0e0)
    at /usr/include/c++/7/thread:186
#11 0x00007ffff6984733 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#12 0x00007ffff72ba6db in start_thread (arg=0x7ffff4cbf700) at pthread_create.c:463
#13 0x00007ffff63de88f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
### Solution
I think calling terminate on the function is causing some bad behavior on the running thread.  
I propose to use the atomic bool ```run``` as a shutdown signal for the capture threads and modifying the destructor to use join. Please consider this PR. It works on my machines. 