### PR TITLE
Fix proposal for #9, disabling shutdown call

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -261,7 +261,6 @@ namespace velodyne
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){
-                    socket->shutdown( boost::asio::ip::udp::socket::shutdown_both );
                     socket->close();
                     delete socket;
                     socket = nullptr;

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -261,7 +261,6 @@ namespace velodyne
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){
-                    socket->shutdown( boost::asio::ip::udp::socket::shutdown_both );
                     socket->close();
                     delete socket;
                     socket = nullptr;

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -261,7 +261,6 @@ namespace velodyne
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){
-                    socket->shutdown( boost::asio::ip::udp::socket::shutdown_both );
                     socket->close();
                     delete socket;
                     socket = nullptr;


### PR DESCRIPTION
This fixes #9. 

Turns out you [should not call shutdown on UDP](https://stackoverflow.com/questions/10118943/getting-transport-endpoint-is-not-connected-in-udp-socket-programming-in-c). I think, just closing the socket is fine. 

We have tested this on a VLP16 sensor ( we had the same problem as #9 ) and the error was corrected( I am on Ubuntu18.04 and gcc 7. ). 

@kafeiyin00, I know it has been some time, but can you check if this works for you?. 
