### PR TITLE
Using move semantics

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -383,9 +383,9 @@ namespace velodyne
                             if( last_azimuth > azimuth ){
                                 // Push One Rotation Data to Queue
                                 mutex.lock();
-                                queue.push( lasers );
+                                queue.push( std::move( lasers ) );
                                 mutex.unlock();
-                                lasers.clear();
+                                lasers = std::vector<Laser>();
                             }
 
                             Laser laser;

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -293,11 +293,11 @@ namespace velodyne
                 // Pop One Rotation Data from Queue
                 if( mutex.try_lock() ){
                     if( !queue.empty() ){
-                        lasers = queue.front();
+                        lasers = std::move( queue.front() );
+                        queue.pop();
                         if( sort ){
                             std::sort( lasers.begin(), lasers.end() );
                         }
-                        queue.pop();
                     }
                     mutex.unlock();
                 }

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -383,9 +383,9 @@ namespace velodyne
                             if( last_azimuth > azimuth ){
                                 // Push One Rotation Data to Queue
                                 mutex.lock();
-                                queue.push( lasers );
+                                queue.push( std::move( lasers ) );
                                 mutex.unlock();
-                                lasers.clear();
+                                lasers = std::vector<Laser>();
                             }
 
                             Laser laser;

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -293,11 +293,11 @@ namespace velodyne
                 // Pop One Rotation Data from Queue
                 if( mutex.try_lock() ){
                     if( !queue.empty() ){
-                        lasers = queue.front();
+                        lasers = std::move( queue.front() );
+                        queue.pop();
                         if( sort ){
                             std::sort( lasers.begin(), lasers.end() );
                         }
-                        queue.pop();
                     }
                     mutex.unlock();
                 }

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -383,9 +383,9 @@ namespace velodyne
                             if( last_azimuth > azimuth ){
                                 // Push One Rotation Data to Queue
                                 mutex.lock();
-                                queue.push( lasers );
+                                queue.push( std::move( lasers ) );
                                 mutex.unlock();
-                                lasers.clear();
+                                lasers = std::vector<Laser>();
                             }
 
                             Laser laser;

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -293,11 +293,11 @@ namespace velodyne
                 // Pop One Rotation Data from Queue
                 if( mutex.try_lock() ){
                     if( !queue.empty() ){
-                        lasers = queue.front();
+                        lasers = std::move( queue.front() );
+                        queue.pop();
                         if( sort ){
                             std::sort( lasers.begin(), lasers.end() );
                         }
-                        queue.pop();
                     }
                     mutex.unlock();
                 }


### PR DESCRIPTION
Hey there again @UnaNancyOwen,


 I was using yesterday this class on a very low resource computer. And I had to come up with some *elegant* tricks, since the queue of this class was causing a small bottleneck. 

This class is a really good place to use move semantics. Whenever you insert(push) and pop on the queue, the element that is being copied into the queue is immediately destroyed. Same with push, intermediately after doing ```lasers = queue.back()``` you do ```queue.pop( )``` and destroy the element. This is almost a book example the use for std::move and emplace(std::move). 

In this PR, I have profiled and changed the mechanisms of insertion and extraction of the queue, so that the massive arrays of the data packets are transferred safely and *copy-less*.

```queue.push(lasers)``` now uses ```queue.push(std::move(lasers))``` improving from 80000ns to 3000ns.

```laser = queue.front();``` is replaced with ```laser = std::move(queue)```. Improving from 40000ns to 300ns. 

As of the laser element that is being pushed back on lasers, using move semantics does not represent an improvement, the data structure is too small.

This has been tested on pcaps and a VLP16, and compiled on gcc7, and validated [here](https://stackoverflow.com/questions/41674179/move-item-to-a-list-without-copying) and [here](https://stackoverflow.com/questions/37173697/is-it-okay-to-move-an-object-from-a-queue-if-youre-about-to-pop-from-it). This will work with absolute certainty on any other compiler. 