### PR TITLE
Distance fix

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -311,6 +311,7 @@ namespace velodyne
 
             int getQueueSize()
             {
+                std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
             }
 

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -309,6 +309,11 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
+            int getQueueSize()
+            {
+                return queue.size();
+            }
+
         private:
             #ifdef HAVE_BOOST
             // Capture Thread from Sensor
@@ -390,7 +395,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;
@@ -498,7 +507,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -311,6 +311,7 @@ namespace velodyne
 
             int getQueueSize()
             {
+                std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
             }
 

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -309,6 +309,11 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
+            int getQueueSize()
+            {
+                return queue.size();
+            }
+
         private:
             #ifdef HAVE_BOOST
             // Capture Thread from Sensor
@@ -390,7 +395,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;
@@ -498,7 +507,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -311,6 +311,7 @@ namespace velodyne
 
             int getQueueSize()
             {
+                std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
             }
 

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -309,6 +309,11 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
+            int getQueueSize()
+            {
+                return queue.size();
+            }
+
         private:
             #ifdef HAVE_BOOST
             // Capture Thread from Sensor
@@ -390,7 +395,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;
@@ -498,7 +507,11 @@ namespace velodyne
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
-                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
+                            #ifdef USE_MILLIMETERS
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0;
+                            #else
+                            laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance * 2.0 / 10;
+                            #endif
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                             laser.time = unixtime;


### PR DESCRIPTION
Hey @UnaNancyOwen, 

Here is a small patch, I have done two things. First and foremost, the return distance from these drivers is wrong on scale.

As you can see here(VLP user manual) the distance after the casting must be multiplied by two and its in millimeters. I have added a macro to switch between centimeters and millis (centimeters are still default)
![image](https://user-images.githubusercontent.com/19253027/41460346-b4f85732-708c-11e8-98a4-7f572ef55a03.png)
This is fixed with this patch, we have tested this on a VLP16. 


I have also added a member function to retrieve the size of the queue, it comes in very handy when having to check that the velodyne (and specially the live connection) is working properly. 
