### PR TITLE
Pr09042018

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -394,8 +394,11 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
 
                             // Update Last Rotation Azimuth
@@ -502,10 +505,12 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -73,7 +73,7 @@ if( PCAP_FOUND OR Boost_FOUND )
   # Additional Dependencies
   target_link_libraries( simple ${CMAKE_THREAD_LIBS_INIT} )
   target_link_libraries( simple ${Boost_LIBRARIES} )
-  target_link_libraries( simple ${PCAP_LIBRARIES} )
+  target_link_libraries( simple ${PCAP_LIBRARIES})
 else()
   message( WARNING "VelodyneCapture need at least either Boost or PCAP." )
 endif()

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -42,6 +42,12 @@ if( PCAP_FOUND )
   set( HAVE_PCAP "-DHAVE_PCAP" )
 endif()
 
+# Use GPS timestamps insead of Unix epoch
+OPTION( HAVE_GPSTIME "Use GPS timestamps instead of Unix " OFF )
+if( HAVE_GPSTIME )
+  add_definitions( -DHAVE_GPSTIME )
+endif()
+
 # Set Properties
 if( PCAP_FOUND OR Boost_FOUND )
   # Additional Include Directories

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -73,7 +73,7 @@ if( PCAP_FOUND OR Boost_FOUND )
   # Additional Dependencies
   target_link_libraries( simple ${CMAKE_THREAD_LIBS_INIT} )
   target_link_libraries( simple ${Boost_LIBRARIES} )
-  target_link_libraries( simple ${PCAP_LIBRARIES})
+  target_link_libraries( simple ${PCAP_LIBRARIES} )
 else()
   message( WARNING "VelodyneCapture need at least either Boost or PCAP." )
 endif()

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -68,7 +68,6 @@ if( PCAP_FOUND OR Boost_FOUND )
 
   # Additional Library Directories
   link_directories( ${Boost_LIBRARY_DIRS} )
-  link_directories( ${PCAP_LIBRARY_DIRS} )
 
   # Additional Dependencies
   target_link_libraries( simple ${CMAKE_THREAD_LIBS_INIT} )

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -43,9 +43,16 @@ if( PCAP_FOUND )
 endif()
 
 # Use GPS timestamps insead of Unix epoch
+# This is specially useful while reading PCAP files.
 OPTION( HAVE_GPSTIME "Use GPS timestamps instead of Unix " OFF )
 if( HAVE_GPSTIME )
   add_definitions( -DHAVE_GPSTIME )
+endif()
+
+# Use millimeters instead of the default, centimeters.
+OPTION( USE_MILLIMETERS "Use millimeters instead of centimeters " OFF )
+if( USE_MILLIMETERS )
+  add_definitions( -DUSE_MILLIMETERS )
 endif()
 
 # Set Properties

--- a/sample/simple/FindPCAP.cmake
+++ b/sample/simple/FindPCAP.cmake
@@ -107,6 +107,8 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
+MESSAGE(${PCAP_LIBRARY_DIR})
+
 set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
@@ -115,85 +117,13 @@ set(CMAKE_REQUIRED_INCLUDES ${PCAP_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCAP DEFAULT_MSG PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
+find_package_handle_standard_args(PCAP DEFAULT_MSG 
+                                  PCAP_INCLUDE_DIRS
+                                  PCAP_LIBRARIES)
 
-mark_as_advanced(PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
-
-
-
-# - Try to find libpcap include dirs and libraries
-#
-# Usage of this module as follows:
-#
-#     find_package(PCAP)
-#
-# Variables used by this module, they can change the default behaviour and need
-# to be set before calling find_package:
-#
-#  PCAP_ROOT_DIR             Set this variable to the root installation of
-#                            libpcap if the module has problems finding the
-#                            proper installation path.
-#
-# Variables defined by this module:
-#
-#  PCAP_FOUND                System has libpcap, include and library dirs found
-#  PCAP_INCLUDE_DIR          The libpcap include directories.
-#  PCAP_LIBRARY              The libpcap library (possibly includes a thread
-#                            library e.g. required by pf_ring's libpcap)
-#  HAVE_PF_RING              If a found version of libpcap supports PF_RING
-
-find_path(PCAP_ROOT_DIR
-    NAMES include/pcap.h
-)
-
-find_path(PCAP_INCLUDE_DIR
-    NAMES pcap.h
-    HINTS ${PCAP_ROOT_DIR}/include
-)
-
-find_library(PCAP_LIBRARY
-    NAMES pcap
-    HINTS ${PCAP_ROOT_DIR}/lib
-)
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCAP DEFAULT_MSG
-    PCAP_LIBRARY
-    PCAP_INCLUDE_DIR
-)
-
-include(CheckCSourceCompiles)
-set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
-check_c_source_compiles("int main() { return 0; }" PCAP_LINKS_SOLO)
-set(CMAKE_REQUIRED_LIBRARIES)
-
-# check if linking against libpcap also needs to link against a thread library
-if (NOT PCAP_LINKS_SOLO)
-    find_package(Threads)
-    if (THREADS_FOUND)
-        set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-        check_c_source_compiles("int main() { return 0; }" PCAP_NEEDS_THREADS)
-        set(CMAKE_REQUIRED_LIBRARIES)
-    endif ()
-    if (THREADS_FOUND AND PCAP_NEEDS_THREADS)
-        set(_tmp ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-        list(REMOVE_DUPLICATES _tmp)
-        set(PCAP_LIBRARY ${_tmp}
-            CACHE STRING "Libraries needed to link against libpcap" FORCE)
-    else ()
-        message(FATAL_ERROR "Couldn't determine how to link against libpcap")
-    endif ()
-endif ()
-
-include(CheckFunctionExists)
-set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
-check_function_exists(pcap_get_pfring_id HAVE_PF_RING)
-set(CMAKE_REQUIRED_LIBRARIES)
-
-mark_as_advanced(
-    PCAP_ROOT_DIR
-    PCAP_INCLUDE_DIR
-    PCAP_LIBRARY
-)
-
-
+if(${PCAP_LIBRARY_DIR})
+find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
+endif()
+mark_as_advanced(PCAP_INCLUDE_DIRS
+                 PCAP_LIBRARY_DIRS
+                 PCAP_LIBRARIES)

--- a/sample/simple/FindPCAP.cmake
+++ b/sample/simple/FindPCAP.cmake
@@ -107,7 +107,6 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
-set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
 include(CheckFunctionExists)
@@ -115,14 +114,6 @@ set(CMAKE_REQUIRED_INCLUDES ${PCAP_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCAP DEFAULT_MSG 
-                                  PCAP_INCLUDE_DIRS
-                                  PCAP_LIBRARIES)
+find_package_handle_standard_args(PCAP DEFAULT_MSG PCAP_LIBRARIES)
 
-if(${PCAP_LIBRARY_DIR})
-find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
-endif()
-
-mark_as_advanced(PCAP_INCLUDE_DIRS
-                 PCAP_LIBRARY_DIRS
-                 PCAP_LIBRARIES)
+mark_as_advanced(PCAP_INCLUDE_DIRS PCAP_LIBRARIES)

--- a/sample/simple/FindPCAP.cmake
+++ b/sample/simple/FindPCAP.cmake
@@ -118,3 +118,82 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PCAP DEFAULT_MSG PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
 
 mark_as_advanced(PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
+
+
+
+# - Try to find libpcap include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(PCAP)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PCAP_ROOT_DIR             Set this variable to the root installation of
+#                            libpcap if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  PCAP_FOUND                System has libpcap, include and library dirs found
+#  PCAP_INCLUDE_DIR          The libpcap include directories.
+#  PCAP_LIBRARY              The libpcap library (possibly includes a thread
+#                            library e.g. required by pf_ring's libpcap)
+#  HAVE_PF_RING              If a found version of libpcap supports PF_RING
+
+find_path(PCAP_ROOT_DIR
+    NAMES include/pcap.h
+)
+
+find_path(PCAP_INCLUDE_DIR
+    NAMES pcap.h
+    HINTS ${PCAP_ROOT_DIR}/include
+)
+
+find_library(PCAP_LIBRARY
+    NAMES pcap
+    HINTS ${PCAP_ROOT_DIR}/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PCAP DEFAULT_MSG
+    PCAP_LIBRARY
+    PCAP_INCLUDE_DIR
+)
+
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
+check_c_source_compiles("int main() { return 0; }" PCAP_LINKS_SOLO)
+set(CMAKE_REQUIRED_LIBRARIES)
+
+# check if linking against libpcap also needs to link against a thread library
+if (NOT PCAP_LINKS_SOLO)
+    find_package(Threads)
+    if (THREADS_FOUND)
+        set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+        check_c_source_compiles("int main() { return 0; }" PCAP_NEEDS_THREADS)
+        set(CMAKE_REQUIRED_LIBRARIES)
+    endif ()
+    if (THREADS_FOUND AND PCAP_NEEDS_THREADS)
+        set(_tmp ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+        list(REMOVE_DUPLICATES _tmp)
+        set(PCAP_LIBRARY ${_tmp}
+            CACHE STRING "Libraries needed to link against libpcap" FORCE)
+    else ()
+        message(FATAL_ERROR "Couldn't determine how to link against libpcap")
+    endif ()
+endif ()
+
+include(CheckFunctionExists)
+set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
+check_function_exists(pcap_get_pfring_id HAVE_PF_RING)
+set(CMAKE_REQUIRED_LIBRARIES)
+
+mark_as_advanced(
+    PCAP_ROOT_DIR
+    PCAP_INCLUDE_DIR
+    PCAP_LIBRARY
+)
+
+

--- a/sample/simple/FindPCAP.cmake
+++ b/sample/simple/FindPCAP.cmake
@@ -107,8 +107,6 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
-MESSAGE(${PCAP_LIBRARY_DIR})
-
 set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
@@ -124,6 +122,7 @@ find_package_handle_standard_args(PCAP DEFAULT_MSG
 if(${PCAP_LIBRARY_DIR})
 find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
 endif()
+
 mark_as_advanced(PCAP_INCLUDE_DIRS
                  PCAP_LIBRARY_DIRS
                  PCAP_LIBRARIES)

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -394,8 +394,11 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
 
                             // Update Last Rotation Azimuth
@@ -502,10 +505,12 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }

--- a/sample/simple/main.cpp
+++ b/sample/simple/main.cpp
@@ -13,11 +13,11 @@ int main( int argc, char* argv[] )
     const unsigned short port = 2368;
     velodyne::VLP16Capture capture( address, port );
     //velodyne::HDL32ECapture capture( address, port );
+    const std::string filename = "/home/e/Downloads/vlp16mrtt-000.pcap";
+    velodyne::VLP16Capture capture( filename );
 
     /*
     // Open VelodyneCapture that retrieve from PCAP
-    const std::string filename = "../file.pcap";
-    velodyne::VLP16Capture capture( filename );
     //velodyne::HDL32ECapture capture( filename );
     */
 
@@ -62,8 +62,8 @@ int main( int argc, char* argv[] )
             std::cout << "id : " << id << "\n";
 
             // Laser TimeStamp ( microseconds )
-            const long long unixtime = laser.time;
-            std::cout << "unixtime : " << unixtime << "\n";
+            const long long timestamp = laser.time;
+            std::cout << "timestamp : " << timestamp << "\n";
 
             /*
             // Laser TimeStamp ( MM/DD/YY hh:mm:ss.ffffff )

--- a/sample/simple/main.cpp
+++ b/sample/simple/main.cpp
@@ -13,11 +13,11 @@ int main( int argc, char* argv[] )
     const unsigned short port = 2368;
     velodyne::VLP16Capture capture( address, port );
     //velodyne::HDL32ECapture capture( address, port );
-    const std::string filename = "/home/e/Downloads/vlp16mrtt-000.pcap";
-    velodyne::VLP16Capture capture( filename );
 
     /*
     // Open VelodyneCapture that retrieve from PCAP
+    const std::string filename = "../file.pcap";
+    velodyne::VLP16Capture capture( filename );
     //velodyne::HDL32ECapture capture( filename );
     */
 

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -91,7 +91,6 @@ if( OpenCV_FOUND AND ( PCAP_FOUND OR Boost_FOUND ) )
 
   # Additional Library Directories
   link_directories( ${Boost_LIBRARY_DIRS} )
-  link_directories( ${PCAP_LIBRARY_DIRS} )
   link_directories( ${OpenCV_LIB_DIR} )
 
   # Additional Dependencies

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -43,9 +43,16 @@ if( PCAP_FOUND )
 endif()
 
 # Use GPS timestamps insead of Unix epoch
+# This is specially useful while reading PCAP files.
 OPTION( HAVE_GPSTIME "Use GPS timestamps instead of Unix " OFF )
 if( HAVE_GPSTIME )
   add_definitions( -DHAVE_GPSTIME )
+endif()
+
+# Use millimeters instead of the default, centimeters.
+OPTION( USE_MILLIMETERS "Use millimeters instead of centimeters " OFF )
+if( USE_MILLIMETERS )
+  add_definitions( -DUSE_MILLIMETERS )
 endif()
 
 # Find Package OpenCV

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -42,6 +42,12 @@ if( PCAP_FOUND )
   set( HAVE_PCAP "-DHAVE_PCAP" )
 endif()
 
+# Use GPS timestamps insead of Unix epoch
+OPTION( HAVE_GPSTIME "Use GPS timestamps instead of Unix " OFF )
+if( HAVE_GPSTIME )
+  add_definitions( -DHAVE_GPSTIME )
+endif()
+
 # Find Package OpenCV
 set( OpenCV_DIR "C:/Program Files/opencv/build" )
 set( OpenCV_STATIC OFF )

--- a/sample/viewer/FindPCAP.cmake
+++ b/sample/viewer/FindPCAP.cmake
@@ -107,6 +107,8 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
+MESSAGE(${PCAP_LIBRARY_DIR})
+
 set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
@@ -115,6 +117,13 @@ set(CMAKE_REQUIRED_INCLUDES ${PCAP_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCAP DEFAULT_MSG PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
+find_package_handle_standard_args(PCAP DEFAULT_MSG 
+                                  PCAP_INCLUDE_DIRS
+                                  PCAP_LIBRARIES)
 
-mark_as_advanced(PCAP_INCLUDE_DIRS PCAP_LIBRARY_DIRS PCAP_LIBRARIES)
+if(${PCAP_LIBRARY_DIR})
+find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
+endif()
+mark_as_advanced(PCAP_INCLUDE_DIRS
+                 PCAP_LIBRARY_DIRS
+                 PCAP_LIBRARIES)

--- a/sample/viewer/FindPCAP.cmake
+++ b/sample/viewer/FindPCAP.cmake
@@ -107,7 +107,6 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
-set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
 include(CheckFunctionExists)
@@ -115,14 +114,6 @@ set(CMAKE_REQUIRED_INCLUDES ${PCAP_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCAP DEFAULT_MSG 
-                                  PCAP_INCLUDE_DIRS
-                                  PCAP_LIBRARIES)
+find_package_handle_standard_args(PCAP DEFAULT_MSG PCAP_LIBRARIES)
 
-if(${PCAP_LIBRARY_DIR})
-find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
-endif()
-
-mark_as_advanced(PCAP_INCLUDE_DIRS
-                 PCAP_LIBRARY_DIRS
-                 PCAP_LIBRARIES)
+mark_as_advanced(PCAP_INCLUDE_DIRS PCAP_LIBRARIES)

--- a/sample/viewer/FindPCAP.cmake
+++ b/sample/viewer/FindPCAP.cmake
@@ -107,8 +107,6 @@ else()
 endif()
 
 set(PCAP_INCLUDE_DIRS ${PCAP_INCLUDE_DIR})
-MESSAGE(${PCAP_LIBRARY_DIR})
-
 set(PCAP_LIBRARY_DIRS ${PCAP_LIBRARY_DIR})
 set(PCAP_LIBRARIES ${PCAP_LIBRARY})
 
@@ -124,6 +122,7 @@ find_package_handle_standard_args(PCAP DEFAULT_MSG
 if(${PCAP_LIBRARY_DIR})
 find_package_handle_standard_args(PCAP_LIBRARY_DIRS)
 endif()
+
 mark_as_advanced(PCAP_INCLUDE_DIRS
                  PCAP_LIBRARY_DIRS
                  PCAP_LIBRARIES)

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -394,8 +394,11 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
 
                             // Update Last Rotation Azimuth
@@ -502,10 +505,12 @@ namespace velodyne
                             laser.distance = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance;
                             laser.intensity = firing_data.laserReturns[laser_index % MAX_NUM_LASERS].intensity;
                             laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                            #ifdef HAVE_GPSTIME
+                            laser.time = packet->gpsTimestamp;
+                            #else
                             laser.time = unixtime;
-
+                            #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }


### PR DESCRIPTION
Hi @UnaNancyOwen , 

As discussed ages ago, this PR contains a preprocessor macro to enable gps time instead of unix time. Still data packet precision ( no shooting delay LUT for now, but this will eventually be implemented) .  I have also completed the CMakeList.txt of both examples to consider this macro. 

The build is kinda messed up, I had to add a bit more of code to make FindPCAP work in Linux. If you had 
a minute to check that the build still works on Windows it would be great (although I am pretty certain it still does). 