### PR TITLE
Fixing headers

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -29,6 +29,8 @@
 #include <cstdint>
 #include <chrono>
 #include <iomanip>
+#include <algorithm>
+#include <functional>
 #ifdef HAVE_BOOST
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -29,6 +29,8 @@
 #include <cstdint>
 #include <chrono>
 #include <iomanip>
+#include <algorithm>
+#include <functional>
 #ifdef HAVE_BOOST
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -29,6 +29,8 @@
 #include <cstdint>
 #include <chrono>
 #include <iomanip>
+#include <algorithm>
+#include <functional>
 #ifdef HAVE_BOOST
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/sample/viewer/main.cpp
+++ b/sample/viewer/main.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <vector>
-#include <algorithm>
 #include <cmath>
 #include <opencv2/opencv.hpp>
 #include <opencv2/viz.hpp>


### PR DESCRIPTION
Ok, this is kinda silly, but \<algorithm\> is included in the main.cpp files and it *should*  technically be included in the header, so that when you import it from another project it imports all its requirements by itself. Also \<algorithm\> is not needed on the viewer as the lasers are not being sorted there.