### PR TITLE
Pcap as fast as possible

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -426,7 +426,6 @@ namespace velodyne
             // Capture Thread from PCAP
             void capturePCAP()
             {
-                run = true;
                 struct timeval last_time = { 0 };
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -311,7 +311,7 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
-            int getQueueSize()
+            size_t getQueueSize()
             {
                 std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
@@ -469,7 +469,9 @@ namespace velodyne
                     }
 
                     const unsigned long long delay = ( ( header->ts.tv_sec - last_time.tv_sec ) * 1000000 ) + ( header->ts.tv_usec - last_time.tv_usec );
+                    #ifndef HAVE_FAST_PCAP
                     std::this_thread::sleep_for( std::chrono::microseconds( delay ) );
+                    #endif
                     last_time = header->ts;
 
                     // Caluculate Interpolated Azimuth

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -42,6 +42,14 @@ if( PCAP_FOUND )
   set( HAVE_PCAP "-DHAVE_PCAP" )
 endif()
 
+# Disable sleep while reading a pcap
+# Is is useful if you have to parse the result of a pcap faster than real
+# time.
+OPTION( HAVE_FAST_PCAP "Avoid sleeping whilst reading PCAP files " OFF )
+if( HAVE_FAST_PCAP )
+  add_definitions( -DHAVE_FAST_PCAP )
+endif()
+
 # Use GPS timestamps insead of Unix epoch
 # This is specially useful while reading PCAP files.
 OPTION( HAVE_GPSTIME "Use GPS timestamps instead of Unix " OFF )

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -426,7 +426,6 @@ namespace velodyne
             // Capture Thread from PCAP
             void capturePCAP()
             {
-                run = true;
                 struct timeval last_time = { 0 };
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -311,7 +311,7 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
-            int getQueueSize()
+            size_t getQueueSize()
             {
                 std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
@@ -469,7 +469,9 @@ namespace velodyne
                     }
 
                     const unsigned long long delay = ( ( header->ts.tv_sec - last_time.tv_sec ) * 1000000 ) + ( header->ts.tv_usec - last_time.tv_usec );
+                    #ifndef HAVE_FAST_PCAP
                     std::this_thread::sleep_for( std::chrono::microseconds( delay ) );
+                    #endif
                     last_time = header->ts;
 
                     // Caluculate Interpolated Azimuth

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -35,6 +35,15 @@ set( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH} )
 set( PCAP_DIR "C:/Program Files/WpdPack" )
 find_package( PCAP )
 
+# Disable sleep while reading a pcap
+# Is is useful if you have to parse the result of a pcap faster than real
+# time.
+
+OPTION( HAVE_FAST_PCAP "Avoid sleeping whilst reading PCAP files " OFF )
+if( HAVE_FAST_PCAP )
+  add_definitions( -DHAVE_FAST_PCAP )
+endif()
+
 # If Capture from PCAP Files, VelodyneCapture are required PCAP.
 # Please Define HAVE_PCAP in Preprocessor.
 set( HAVE_PCAP )

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -426,7 +426,6 @@ namespace velodyne
             // Capture Thread from PCAP
             void capturePCAP()
             {
-                run = true;
                 struct timeval last_time = { 0 };
                 double last_azimuth = 0.0;
                 std::vector<Laser> lasers;

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -311,7 +311,7 @@ namespace velodyne
                 retrieve( lasers, false );
             };
 
-            int getQueueSize()
+            size_t getQueueSize()
             {
                 std::lock_guard<std::mutex> lock( mutex );
                 return queue.size();
@@ -469,7 +469,9 @@ namespace velodyne
                     }
 
                     const unsigned long long delay = ( ( header->ts.tv_sec - last_time.tv_sec ) * 1000000 ) + ( header->ts.tv_usec - last_time.tv_usec );
+                    #ifndef HAVE_FAST_PCAP
                     std::this_thread::sleep_for( std::chrono::microseconds( delay ) );
+                    #endif
                     last_time = header->ts;
 
                     // Caluculate Interpolated Azimuth


### PR DESCRIPTION
We are parsing PCAP files and we don't really need the time to be the same as the Velodyne, we would to parse it as fast as possible.  For this reason, we have added the HAVE_FAST_PCAP macro in this PR to disable the sleeping time whilst reading data packets. 

I am also a bit concerned as the queue gets filled without any restrictions. Is this the desired behavior?. If the queue is not emptied with >> the buffer grows a lot and hogs *a lot* of memory. In the past I have controlled this externally with the method getQueueSize() but perhaps a more desirable solution would be to limit the size of the buffer by:

- Not accepting more data packets after the buffer is full.
- By popping the last element on the queue (automatically) and inserting a new one-
- Maybe this is the desired behavior and do nothing. 

