### PR TITLE
Not pushing empty points

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -395,9 +395,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -512,9 +514,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -396,7 +396,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif
@@ -515,7 +515,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -39,6 +39,7 @@
 #ifdef HAVE_PCAP
 #include <pcap.h>
 #endif
+#define EPSILON 0.001
 
 namespace velodyne
 {
@@ -394,7 +395,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -411,7 +414,6 @@ namespace velodyne
                             laser.time = unixtime;
                             #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }
@@ -510,7 +512,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -63,6 +63,12 @@ if( USE_MILLIMETERS )
   add_definitions( -DUSE_MILLIMETERS )
 endif()
 
+# Don't push null returns to the lases queue
+OPTION( NO_EMPTY_RETURNS "Discard empty returns before pushing them to the laser queue" OFF )
+if( NO_EMPTY_RETURNS )
+  add_definitions( -DNO_EMTPTY_RETURNS )
+endif()
+
 # Set Properties
 if( PCAP_FOUND OR Boost_FOUND )
   # Additional Include Directories

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -395,9 +395,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -512,9 +514,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -396,7 +396,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif
@@ -515,7 +515,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -39,6 +39,7 @@
 #ifdef HAVE_PCAP
 #include <pcap.h>
 #endif
+#define EPSILON 0.001
 
 namespace velodyne
 {
@@ -394,7 +395,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -411,7 +414,6 @@ namespace velodyne
                             laser.time = unixtime;
                             #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }
@@ -510,7 +512,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -64,6 +64,12 @@ if( USE_MILLIMETERS )
   add_definitions( -DUSE_MILLIMETERS )
 endif()
 
+# Don't push null returns to the lases queue
+OPTION( NO_EMPTY_RETURNS "Discard empty returns before pushing them to the laser queue" OFF )
+if( NO_EMPTY_RETURNS )
+  add_definitions( -DNO_EMTPTY_RETURNS )
+endif()
+
 # Find Package OpenCV
 set( OpenCV_DIR "C:/Program Files/opencv/build" )
 set( OpenCV_STATIC OFF )

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -395,9 +395,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -512,9 +514,11 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
+                            #ifdef NO_EMPTY_RETURNS
                             if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
+                            #endif
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -396,7 +396,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif
@@ -515,7 +515,7 @@ namespace velodyne
                                 lasers.clear();
                             }
                             #ifdef NO_EMPTY_RETURNS
-                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                            if( firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
                               continue;
                             }
                             #endif

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -39,6 +39,7 @@
 #ifdef HAVE_PCAP
 #include <pcap.h>
 #endif
+#define EPSILON 0.001
 
 namespace velodyne
 {
@@ -394,7 +395,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];
@@ -411,7 +414,6 @@ namespace velodyne
                             laser.time = unixtime;
                             #endif
                             lasers.push_back( laser );
-
                             // Update Last Rotation Azimuth
                             last_azimuth = azimuth;
                         }
@@ -510,7 +512,9 @@ namespace velodyne
                                 mutex.unlock();
                                 lasers.clear();
                             }
-
+                            if (firing_data.laserReturns[laser_index % MAX_NUM_LASERS].distance < EPSILON ){
+                              continue;
+                            }
                             Laser laser;
                             laser.azimuth = azimuth / 100.0;
                             laser.vertical = lut[laser_index % MAX_NUM_LASERS];


### PR DESCRIPTION
Hey @UnaNancyOwen 

As you might know already, both VLP16 and HDL32 return a 0 distance detection whenever the return was not detected. In these drivers, those points are also put in the queue. This ends up being a decent overhead, processing and memory wise. We consider that the empty points should be filtered *upstream* to avoid such overhead. 

Please consider this PR. 
Thank you very much!