### PR TITLE
Fixing deadlock, fixing typo

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -251,7 +251,6 @@ namespace velodyne
             // Close Capture
             void close()
             {
-                std::lock_guard<std::mutex> lock( mutex );
                 run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
@@ -261,6 +260,7 @@ namespace velodyne
                     thread = nullptr;
                 }
 
+                std::lock_guard<std::mutex> lock( mutex );
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){

--- a/sample/simple/CMakeLists.txt
+++ b/sample/simple/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 # Don't push null returns to the lases queue
 OPTION( NO_EMPTY_RETURNS "Discard empty returns before pushing them to the laser queue" OFF )
 if( NO_EMPTY_RETURNS )
-  add_definitions( -DNO_EMTPTY_RETURNS )
+  add_definitions( -DNO_EMPTY_RETURNS )
 endif()
 
 # Set Properties

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -251,7 +251,6 @@ namespace velodyne
             // Close Capture
             void close()
             {
-                std::lock_guard<std::mutex> lock( mutex );
                 run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
@@ -261,6 +260,7 @@ namespace velodyne
                     thread = nullptr;
                 }
 
+                std::lock_guard<std::mutex> lock( mutex );
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){

--- a/sample/viewer/CMakeLists.txt
+++ b/sample/viewer/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 # Don't push null returns to the lases queue
 OPTION( NO_EMPTY_RETURNS "Discard empty returns before pushing them to the laser queue" OFF )
 if( NO_EMPTY_RETURNS )
-  add_definitions( -DNO_EMTPTY_RETURNS )
+  add_definitions( -DNO_EMPTY_RETURNS )
 endif()
 
 # Find Package OpenCV

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -251,7 +251,6 @@ namespace velodyne
             // Close Capture
             void close()
             {
-                std::lock_guard<std::mutex> lock( mutex );
                 run = false;
                 // Close Capturte Thread
                 if( thread && thread->joinable() ){
@@ -261,6 +260,7 @@ namespace velodyne
                     thread = nullptr;
                 }
 
+                std::lock_guard<std::mutex> lock( mutex );
                 #ifdef HAVE_BOOST
                 // Close Socket
                 if( socket && socket->is_open() ){


### PR DESCRIPTION
We had a deadlock in the mutex lock, the bug locked the destruction of the objects created and it was aggravated with the new PUSH_SINGLE_PACKETS macro, but also it was likely to happen without the macro, 48 times less likely (the rate of datapackets per revolution) but still affected. This PR should fix it. Also a typo was corrected in the CMakeLists files. 

