### PR TITLE
Adding azimuth point interpolation, fixing bugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@ VelodyneCapture
 ===============
 
 VelodyneCapture is the general capture class to retrieve the laser data from Velodyne sensors using Boost.Asio and PCAP.  
-VelodyneCapture will be able to retrieve lasers infomation about azimuth, vertical and distance that capture at one rotation.  
+VelodyneCapture will be able to retrieve lasers infomation about azimuth, vertical and distance that capture at one rotation or a single data packet.  
 This class supports direct capture form Velodyne sensors, or capture from PCAP files.  
-( This class only supports VLP-16 and HDL-32E sensor, and not supports Dual Return mode. )  
+( This class only supports VLP-16 and HDL-32E sensor, it does not support Dual Return mode. )  
 
 
 Environment
 -----------
-If direct capture from sensors, VelodyneCapture are requires Boost.Asio and its dependent libraries ( Boost.System, Boost.Date_Time, Boost.Regex ).  
+If direct capture from sensors is desired, VelodyneCapture are requires Boost.Asio and its dependent libraries ( Boost.System, Boost.Date_Time, Boost.Regex ).  
 Please define <code>HAVE_BOOST</code> in preprocessor.  
 * Boost.Asio  
 
-If capture from PCAP files, VelodyneCapture are requires PCAP.  
+If capture from PCAP files is instead desired, VelodyneCapture requires PCAP.  
 Please define <code>HAVE_PCAP</code> in preprocessor.  
 * libpcap ( or WinPCAP )  
 
@@ -22,12 +22,12 @@ Sample
 ------
 This repository has two sample programs.  
 * simple  
-  This sample program is displayed data on standard output.  
-  This sample program depends on dependent libraries ( Boost.Asio or libpcap ( or WinPCAP ) ) of VelodyneCapture class.  
+  This sample program displays data on standard output.  
+  This sample program depends on the following libraries: ( Boost.Asio or libpcap ( or WinPCAP ) ) of VelodyneCapture class.  
 
 * viewer  
-  This sample program is displayed data on point cloud.  
-  This sample program depends on OpenCV Viz module in addition to dependent libraries ( Boost.Asio or libpcap ( or WinPCAP ) ) of VelodyneCapture class.  
+  This sample program displays data on a point cloud viewer.  
+  This sample program depends on OpenCV Viz module in addition to the above libraries ( Boost.Asio or libpcap ( or WinPCAP ) ) of VelodyneCapture class.  
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This class supports direct capture form Velodyne sensors, or capture from PCAP f
 
 Environment
 -----------
-If direct capture from sensors is desired, VelodyneCapture are requires Boost.Asio and its dependent libraries ( Boost.System, Boost.Date_Time, Boost.Regex ).  
+If direct capture from sensors is desired, VelodyneCapture requires Boost.Asio and its dependent libraries ( Boost.System, Boost.Date_Time, Boost.Regex ).  
 Please define <code>HAVE_BOOST</code> in preprocessor.  
 * Boost.Asio  
 

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -328,11 +328,12 @@ namespace velodyne
         private:
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
-              if( packet->sensorType != 0x21 && packet->sensorType != 0x22 )
-                  throw(std::runtime_error("This sensor is not supported"));
-              if( packet->mode != 0x37 && packet->mode != 0x38){
-                  throw(std::runtime_error("Sensor can't be set in dual return mode"));
-              }
+            if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
+                throw(std::runtime_error("This sensor is not supported"));
+            }
+            if( packet->mode != 0x37 && packet->mode != 0x38){
+                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+            }
 
               // Retrieve Unix Time ( microseconds )
               const std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
@@ -391,9 +392,9 @@ namespace velodyne
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
                       laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
-                      laser.time = packet->gpsTimestamp;
+                      laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
-                      laser.time = unixtime;
+                      laser.time = unixtime + static_cast<long long>( laser_relative_time );
                       #endif
                       lasers.push_back( laser );
                       // Update Last Rotation Azimuth

--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -329,10 +329,10 @@ namespace velodyne
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
             if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
-                throw(std::runtime_error("This sensor is not supported"));
+                throw( std::runtime_error( "This sensor is not supported" ) );
             }
             if( packet->mode != 0x37 && packet->mode != 0x38){
-                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+                throw( std::runtime_error( "Sensor can't be set in dual return mode" ) );
             }
 
               // Retrieve Unix Time ( microseconds )
@@ -340,13 +340,13 @@ namespace velodyne
               const std::chrono::microseconds epoch = std::chrono::duration_cast<std::chrono::microseconds>( now.time_since_epoch() );
               const long long unixtime = epoch.count();
 
-              // Caluculate Interpolated Azimuth
-              double interpolated = 0.0;
+              // Azimuth delta is the angle from one firing sequence to the next one
+              double azimuth_delta = 0.0;
               if( packet->firingData[1].rotationalPosition < packet->firingData[0].rotationalPosition ){
-                  interpolated = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
               }
               else{
-                  interpolated = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
               }
 
               // Processing Packet
@@ -358,7 +358,7 @@ namespace velodyne
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
                       double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += azimuth_delta * laser_relative_time / time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -535,7 +535,7 @@ namespace velodyne
             static const int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
-            const double time_half_idle = 0.0;
+            const double time_half_idle = 0.0; //All the firings are consecutive
             const double time_total_cycle = 46.080;
 
         public:

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -328,11 +328,12 @@ namespace velodyne
         private:
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
-              if( packet->sensorType != 0x21 && packet->sensorType != 0x22 )
-                  throw(std::runtime_error("This sensor is not supported"));
-              if( packet->mode != 0x37 && packet->mode != 0x38){
-                  throw(std::runtime_error("Sensor can't be set in dual return mode"));
-              }
+            if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
+                throw(std::runtime_error("This sensor is not supported"));
+            }
+            if( packet->mode != 0x37 && packet->mode != 0x38){
+                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+            }
 
               // Retrieve Unix Time ( microseconds )
               const std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
@@ -391,9 +392,9 @@ namespace velodyne
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
                       laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
-                      laser.time = packet->gpsTimestamp;
+                      laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
-                      laser.time = unixtime;
+                      laser.time = unixtime + static_cast<long long>( laser_relative_time );
                       #endif
                       lasers.push_back( laser );
                       // Update Last Rotation Azimuth

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -329,10 +329,10 @@ namespace velodyne
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
             if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
-                throw(std::runtime_error("This sensor is not supported"));
+                throw( std::runtime_error( "This sensor is not supported" ) );
             }
             if( packet->mode != 0x37 && packet->mode != 0x38){
-                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+                throw( std::runtime_error( "Sensor can't be set in dual return mode" ) );
             }
 
               // Retrieve Unix Time ( microseconds )
@@ -340,13 +340,13 @@ namespace velodyne
               const std::chrono::microseconds epoch = std::chrono::duration_cast<std::chrono::microseconds>( now.time_since_epoch() );
               const long long unixtime = epoch.count();
 
-              // Caluculate Interpolated Azimuth
-              double interpolated = 0.0;
+              // Azimuth delta is the angle from one firing sequence to the next one
+              double azimuth_delta = 0.0;
               if( packet->firingData[1].rotationalPosition < packet->firingData[0].rotationalPosition ){
-                  interpolated = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
               }
               else{
-                  interpolated = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
               }
 
               // Processing Packet
@@ -358,7 +358,7 @@ namespace velodyne
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
                       double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += azimuth_delta * laser_relative_time / time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -535,7 +535,7 @@ namespace velodyne
             static const int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
-            const double time_half_idle = 0.0;
+            const double time_half_idle = 0.0; //All the firings are consecutive
             const double time_total_cycle = 46.080;
 
         public:

--- a/sample/simple/main.cpp
+++ b/sample/simple/main.cpp
@@ -9,9 +9,7 @@
 int main( int argc, char* argv[] )
 {
     // Open VelodyneCapture that retrieve from Sensor
-    const boost::asio::ip::address address = boost::asio::ip::address::from_string( "192.168.1.21" );
-    const unsigned short port = 2368;
-    velodyne::VLP16Capture capture( address, port );
+    velodyne::VLP16Capture capture( "/home/e/Downloads/vlp16mrtt-000.pcap" );
     //velodyne::HDL32ECapture capture( address, port );
 
     /*

--- a/sample/simple/main.cpp
+++ b/sample/simple/main.cpp
@@ -9,7 +9,9 @@
 int main( int argc, char* argv[] )
 {
     // Open VelodyneCapture that retrieve from Sensor
-    velodyne::VLP16Capture capture( "/home/e/Downloads/vlp16mrtt-000.pcap" );
+    const boost::asio::ip::address address = boost::asio::ip::address::from_string( "192.168.1.21" );
+    const unsigned short port = 2368;
+    velodyne::VLP16Capture capture( address, port );
     //velodyne::HDL32ECapture capture( address, port );
 
     /*

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -328,11 +328,12 @@ namespace velodyne
         private:
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
-              if( packet->sensorType != 0x21 && packet->sensorType != 0x22 )
-                  throw(std::runtime_error("This sensor is not supported"));
-              if( packet->mode != 0x37 && packet->mode != 0x38){
-                  throw(std::runtime_error("Sensor can't be set in dual return mode"));
-              }
+            if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
+                throw(std::runtime_error("This sensor is not supported"));
+            }
+            if( packet->mode != 0x37 && packet->mode != 0x38){
+                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+            }
 
               // Retrieve Unix Time ( microseconds )
               const std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
@@ -391,9 +392,9 @@ namespace velodyne
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
                       laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
-                      laser.time = packet->gpsTimestamp;
+                      laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
-                      laser.time = unixtime;
+                      laser.time = unixtime + static_cast<long long>( laser_relative_time );
                       #endif
                       lasers.push_back( laser );
                       // Update Last Rotation Azimuth

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -329,10 +329,10 @@ namespace velodyne
           void parseDataPacket( const DataPacket* packet, std::vector<Laser>& lasers, double& last_azimuth )
           {
             if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
-                throw(std::runtime_error("This sensor is not supported"));
+                throw( std::runtime_error( "This sensor is not supported" ) );
             }
             if( packet->mode != 0x37 && packet->mode != 0x38){
-                throw(std::runtime_error("Sensor can't be set in dual return mode"));
+                throw( std::runtime_error( "Sensor can't be set in dual return mode" ) );
             }
 
               // Retrieve Unix Time ( microseconds )
@@ -340,13 +340,13 @@ namespace velodyne
               const std::chrono::microseconds epoch = std::chrono::duration_cast<std::chrono::microseconds>( now.time_since_epoch() );
               const long long unixtime = epoch.count();
 
-              // Caluculate Interpolated Azimuth
-              double interpolated = 0.0;
+              // Azimuth delta is the angle from one firing sequence to the next one
+              double azimuth_delta = 0.0;
               if( packet->firingData[1].rotationalPosition < packet->firingData[0].rotationalPosition ){
-                  interpolated = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( ( packet->firingData[1].rotationalPosition + 36000 ) - packet->firingData[0].rotationalPosition );
               }
               else{
-                  interpolated = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
+                  azimuth_delta = ( packet->firingData[1].rotationalPosition - packet->firingData[0].rotationalPosition );
               }
 
               // Processing Packet
@@ -358,7 +358,7 @@ namespace velodyne
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
                       double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += azimuth_delta * laser_relative_time / time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -535,7 +535,7 @@ namespace velodyne
             static const int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
-            const double time_half_idle = 0.0;
+            const double time_half_idle = 0.0; //All the firings are consecutive
             const double time_total_cycle = 46.080;
 
         public:


### PR DESCRIPTION
This is a rather big commit, a lot of changes:

- First off, there was still one place where the distances were incorrectly indexed, here: 

```c++
                      #ifdef NO_EMPTY_RETURNS
                      if( firing_data.laserReturns[laser_index].distance < EPSILON ){
                          continue;
                      }
                      #endif
```
- Next thing, we refactored the DataPacket parsing process and we put it in a single function in order to avoid code duplicity which is sometimes very annoying. 
- The sensor now throws a runtime error when the model is not correct or the dual return is enabled. The mischief the wrong sensor or the dual return flag produce is definitely not worth it:
```c++
            if( packet->sensorType != 0x21 && packet->sensorType != 0x22 ){
                throw(std::runtime_error("This sensor is not supported"));
            }
            if( packet->mode != 0x37 && packet->mode != 0x38){
                throw(std::runtime_error("Sensor can't be set in dual return mode"));
            }

```
-Perhaps the most important change in this commit is the point to point azimuth interpolation and timestamp. 

We added three new variables 

```
            const double time_between_firings = 1.152;
            const double time_half_idle = 0.0;
            const double time_total_cycle = 46.080;

```
Based on the firing sequence of the HDL32 
![HDL32](https://i.imgur.com/vGUDOi6l.png)

And the one of the VLP16, please bear in mind that this picture of the VLP16 accounts only for half a firing secuence (16 firings).

![VLP16](http://i.imgur.com/ioY0XPD.png)


This requires a lot of review, so I am looking forward to hearing about your opinion on the commit. :smile: 


