### PR TITLE
Fixing casting issues

### DIFF
--- a/VelodyneCapture.h
+++ b/VelodyneCapture.h
@@ -82,7 +82,7 @@ namespace velodyne
             std::mutex mutex;
             std::queue<std::vector<Laser>> queue;
 
-            int MAX_NUM_LASERS;
+            unsigned int MAX_NUM_LASERS;
             std::vector<double> lut;
             double time_between_firings;
             double time_half_idle;
@@ -356,9 +356,10 @@ namespace velodyne
                   for( int laser_index = 0; laser_index < LASER_PER_FIRING; laser_index++ ){
                       // Retrieve Rotation Azimuth
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
-                      double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
+                      double laser_relative_time = LASER_PER_FIRING * VelodyneCapture::time_between_firings + VelodyneCapture::time_half_idle *
+                        (laser_index / VelodyneCapture::MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += interpolated * laser_relative_time / VelodyneCapture::time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -383,14 +384,14 @@ namespace velodyne
                       #endif
                       Laser laser;
                       laser.azimuth = azimuth / 100.0f;
-                      laser.vertical = lut[laser_index % MAX_NUM_LASERS];
+                      laser.vertical = VelodyneCapture::lut[laser_index % VelodyneCapture::MAX_NUM_LASERS];
                       #ifdef USE_MILLIMETERS
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f;
                       #else
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f / 10.0f;
                       #endif
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
-                      laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                      laser.id = static_cast<unsigned char>( laser_index % VelodyneCapture::MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
                       laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
@@ -488,7 +489,7 @@ namespace velodyne
     class VLP16Capture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 16;
+            static const unsigned int MAX_NUM_LASERS = 16;
             const std::vector<double> lut = { -15.0, 1.0, -13.0, 3.0, -11.0, 5.0, -9.0, 7.0, -7.0, 9.0, -5.0, 11.0, -3.0, 13.0, -1.0, 15.0 };
             const double time_between_firings = 2.304;
             const double time_half_idle = 18.432;
@@ -521,18 +522,18 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
-                VelodyneCapture::time_total_cycle = time_total_cycle;
+                VelodyneCapture::MAX_NUM_LASERS = VLP16Capture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = VLP16Capture::lut;
+                VelodyneCapture::time_between_firings = VLP16Capture::time_between_firings;
+                VelodyneCapture::time_half_idle = VLP16Capture::time_half_idle;
+                VelodyneCapture::time_total_cycle = VLP16Capture::time_total_cycle;
             };
     };
 
     class HDL32ECapture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 32;
+            static const unsigned int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
             const double time_half_idle = 0.0;
@@ -565,10 +566,10 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
+                VelodyneCapture::MAX_NUM_LASERS = HDL32ECapture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = HDL32ECapture::lut;
+                VelodyneCapture::time_between_firings = HDL32ECapture::time_between_firings;
+                VelodyneCapture::time_half_idle = HDL32ECapture::time_half_idle;
                 VelodyneCapture::time_total_cycle = time_total_cycle;
             };
     };

--- a/sample/simple/VelodyneCapture.h
+++ b/sample/simple/VelodyneCapture.h
@@ -82,7 +82,7 @@ namespace velodyne
             std::mutex mutex;
             std::queue<std::vector<Laser>> queue;
 
-            int MAX_NUM_LASERS;
+            unsigned int MAX_NUM_LASERS;
             std::vector<double> lut;
             double time_between_firings;
             double time_half_idle;
@@ -356,9 +356,10 @@ namespace velodyne
                   for( int laser_index = 0; laser_index < LASER_PER_FIRING; laser_index++ ){
                       // Retrieve Rotation Azimuth
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
-                      double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
+                      double laser_relative_time = LASER_PER_FIRING * VelodyneCapture::time_between_firings + VelodyneCapture::time_half_idle *
+                        (laser_index / VelodyneCapture::MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += interpolated * laser_relative_time / VelodyneCapture::time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -383,14 +384,14 @@ namespace velodyne
                       #endif
                       Laser laser;
                       laser.azimuth = azimuth / 100.0f;
-                      laser.vertical = lut[laser_index % MAX_NUM_LASERS];
+                      laser.vertical = VelodyneCapture::lut[laser_index % VelodyneCapture::MAX_NUM_LASERS];
                       #ifdef USE_MILLIMETERS
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f;
                       #else
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f / 10.0f;
                       #endif
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
-                      laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                      laser.id = static_cast<unsigned char>( laser_index % VelodyneCapture::MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
                       laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
@@ -488,7 +489,7 @@ namespace velodyne
     class VLP16Capture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 16;
+            static const unsigned int MAX_NUM_LASERS = 16;
             const std::vector<double> lut = { -15.0, 1.0, -13.0, 3.0, -11.0, 5.0, -9.0, 7.0, -7.0, 9.0, -5.0, 11.0, -3.0, 13.0, -1.0, 15.0 };
             const double time_between_firings = 2.304;
             const double time_half_idle = 18.432;
@@ -521,18 +522,18 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
-                VelodyneCapture::time_total_cycle = time_total_cycle;
+                VelodyneCapture::MAX_NUM_LASERS = VLP16Capture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = VLP16Capture::lut;
+                VelodyneCapture::time_between_firings = VLP16Capture::time_between_firings;
+                VelodyneCapture::time_half_idle = VLP16Capture::time_half_idle;
+                VelodyneCapture::time_total_cycle = VLP16Capture::time_total_cycle;
             };
     };
 
     class HDL32ECapture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 32;
+            static const unsigned int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
             const double time_half_idle = 0.0;
@@ -565,10 +566,10 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
+                VelodyneCapture::MAX_NUM_LASERS = HDL32ECapture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = HDL32ECapture::lut;
+                VelodyneCapture::time_between_firings = HDL32ECapture::time_between_firings;
+                VelodyneCapture::time_half_idle = HDL32ECapture::time_half_idle;
                 VelodyneCapture::time_total_cycle = time_total_cycle;
             };
     };

--- a/sample/viewer/VelodyneCapture.h
+++ b/sample/viewer/VelodyneCapture.h
@@ -82,7 +82,7 @@ namespace velodyne
             std::mutex mutex;
             std::queue<std::vector<Laser>> queue;
 
-            int MAX_NUM_LASERS;
+            unsigned int MAX_NUM_LASERS;
             std::vector<double> lut;
             double time_between_firings;
             double time_half_idle;
@@ -356,9 +356,10 @@ namespace velodyne
                   for( int laser_index = 0; laser_index < LASER_PER_FIRING; laser_index++ ){
                       // Retrieve Rotation Azimuth
                       double azimuth = static_cast<double>( firing_data.rotationalPosition );
-                      double laser_relative_time = LASER_PER_FIRING * time_between_firings + time_half_idle* (laser_index / MAX_NUM_LASERS);
+                      double laser_relative_time = LASER_PER_FIRING * VelodyneCapture::time_between_firings + VelodyneCapture::time_half_idle *
+                        (laser_index / VelodyneCapture::MAX_NUM_LASERS);
 
-                      azimuth += interpolated * laser_relative_time / time_total_cycle;
+                      azimuth += interpolated * laser_relative_time / VelodyneCapture::time_total_cycle;
 
                       // Reset Rotation Azimuth
                       if( azimuth >= 36000 )
@@ -383,14 +384,14 @@ namespace velodyne
                       #endif
                       Laser laser;
                       laser.azimuth = azimuth / 100.0f;
-                      laser.vertical = lut[laser_index % MAX_NUM_LASERS];
+                      laser.vertical = VelodyneCapture::lut[laser_index % VelodyneCapture::MAX_NUM_LASERS];
                       #ifdef USE_MILLIMETERS
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f;
                       #else
                       laser.distance = static_cast<float>( firing_data.laserReturns[laser_index].distance ) * 2.0f / 10.0f;
                       #endif
                       laser.intensity = firing_data.laserReturns[laser_index].intensity;
-                      laser.id = static_cast<unsigned char>( laser_index % MAX_NUM_LASERS );
+                      laser.id = static_cast<unsigned char>( laser_index % VelodyneCapture::MAX_NUM_LASERS );
                       #ifdef HAVE_GPSTIME
                       laser.time = packet->gpsTimestamp + static_cast<long long>( laser_relative_time );
                       #else
@@ -488,7 +489,7 @@ namespace velodyne
     class VLP16Capture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 16;
+            static const unsigned int MAX_NUM_LASERS = 16;
             const std::vector<double> lut = { -15.0, 1.0, -13.0, 3.0, -11.0, 5.0, -9.0, 7.0, -7.0, 9.0, -5.0, 11.0, -3.0, 13.0, -1.0, 15.0 };
             const double time_between_firings = 2.304;
             const double time_half_idle = 18.432;
@@ -521,18 +522,18 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
-                VelodyneCapture::time_total_cycle = time_total_cycle;
+                VelodyneCapture::MAX_NUM_LASERS = VLP16Capture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = VLP16Capture::lut;
+                VelodyneCapture::time_between_firings = VLP16Capture::time_between_firings;
+                VelodyneCapture::time_half_idle = VLP16Capture::time_half_idle;
+                VelodyneCapture::time_total_cycle = VLP16Capture::time_total_cycle;
             };
     };
 
     class HDL32ECapture : public VelodyneCapture
     {
         private:
-            static const int MAX_NUM_LASERS = 32;
+            static const unsigned int MAX_NUM_LASERS = 32;
             const std::vector<double> lut = { -30.67, -9.3299999, -29.33, -8.0, -28, -6.6700001, -26.67, -5.3299999, -25.33, -4.0, -24.0, -2.6700001, -22.67, -1.33, -21.33, 0.0, -20.0, 1.33, -18.67, 2.6700001, -17.33, 4.0, -16, 5.3299999, -14.67, 6.6700001, -13.33, 8.0, -12.0, 9.3299999, -10.67, 10.67 };
             const double time_between_firings = 1.152;
             const double time_half_idle = 0.0;
@@ -565,10 +566,10 @@ namespace velodyne
         private:
             void initialize()
             {
-                VelodyneCapture::MAX_NUM_LASERS = MAX_NUM_LASERS;
-                VelodyneCapture::lut = lut;
-                VelodyneCapture::time_between_firings = time_between_firings;
-                VelodyneCapture::time_half_idle = time_half_idle;
+                VelodyneCapture::MAX_NUM_LASERS = HDL32ECapture::MAX_NUM_LASERS;
+                VelodyneCapture::lut = HDL32ECapture::lut;
+                VelodyneCapture::time_between_firings = HDL32ECapture::time_between_firings;
+                VelodyneCapture::time_half_idle = HDL32ECapture::time_half_idle;
                 VelodyneCapture::time_total_cycle = time_total_cycle;
             };
     };


### PR DESCRIPTION
Hi, 

We are having issues again with the drivers. This time around the problem was that when casting to the base class some of the variables MAX_NUM_LASERS, time_between_firings, etc ended up pointing to garbage. This PR should fix it as all the variables refer now to the one in the base class (VelodyneCapture) properly. 

Cheers!
 